### PR TITLE
CASMCMS-9410: RetrySessionManager: Work around Python typing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] - 2025-05-05
+
+### Changed
+- CASMCMS-9410: Add `TYPE_CHECKING`-only code in `RetrySessionManager` to work around  https://github.com/python/typing/issues/1992
+
 ## [2.0.1] - 2024-12-06
 
 ### Fixed

--- a/requests_retry_session/retry_session_manager.py
+++ b/requests_retry_session/retry_session_manager.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -34,7 +34,7 @@ from .timeout_http_adapter import TimeoutHTTPAdapter
 if TYPE_CHECKING:
     from types import TracebackType
     from typing import Iterator, Optional, Type
-    from typing_extensions import Unpack
+    from typing_extensions import Self, Unpack
 
 
 class RetrySessionManager(AbstractContextManager):
@@ -64,6 +64,11 @@ class RetrySessionManager(AbstractContextManager):
             self._requests_adapter = None
         # The following return statement is not needed, but it makes mypy sad without it
         return None
+
+    # The following is needed to work around https://github.com/python/typing/issues/1992
+    if TYPE_CHECKING:
+        def __enter__(self) -> Self:
+            return self
 
     @property
     def requests_session(self) -> requests.Session:


### PR DESCRIPTION
This adds code to `RetrySessionManager` to work around a Python typing issue. The code is all inside `TYPE_CHECKING` conditionals, so will have no runtime impact.

See https://github.com/python/typing/issues/1992 for details on the issue it is correcting.
